### PR TITLE
Ignore all .DS_Store files in repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .generator/
+.DS_Store


### PR DESCRIPTION
Updates the `.gitignore` to exclude `.DS_Store` files from being tracked. These files are created automatically by macOS and contain folder attributes. They are not relevant to the project's code and can clutter the repository. Ignoring them helps keep our repository clean and focused only on relevant source files.